### PR TITLE
Make astroquery a recipe build

### DIFF
--- a/recipe_templates/astroquery/bld.bat
+++ b/recipe_templates/astroquery/bld.bat
@@ -1,4 +1,4 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record foo.txt
+"%PYTHON%" setup.py install --offline
 if errorlevel 1 exit 1
 
 :: Add more build steps here, if they are necessary.

--- a/recipe_templates/astroquery/bld.bat
+++ b/recipe_templates/astroquery/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record foo.txt
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipe_templates/astroquery/build.sh
+++ b/recipe_templates/astroquery/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=/tmp/foo.txt
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipe_templates/astroquery/build.sh
+++ b/recipe_templates/astroquery/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-$PYTHON setup.py install --single-version-externally-managed --record=/tmp/foo.txt
+$PYTHON setup.py install --offline
 
 # Add more build steps here, if they are necessary.
 

--- a/recipe_templates/astroquery/meta.yaml
+++ b/recipe_templates/astroquery/meta.yaml
@@ -1,0 +1,135 @@
+package:
+  name: astroquery
+  version: "{{version}}"
+
+source:
+  fn: astroquery-{{version}}.tar.gz
+  url: https://pypi.python.org/packages/source/a/astroquery/astroquery-{{version}}.tar.gz
+  md5: {{md5}}
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - astroquery = astroquery:main
+    #
+    # Would create an entry point called astroquery that calls astroquery.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - astropy >=0.4.1
+    - requests >=2.4.3
+    - keyring >=4.0
+    - beautiful-soup >=4.3.2
+    - html5lib >=0.999
+
+  run:
+    - python
+    - astropy >=0.4.1
+    - requests >=2.4.3
+    - keyring >=4.0
+    - beautiful-soup >=4.3.2
+    - html5lib >=0.999
+
+test:
+  # Python imports
+  imports:
+    - astroquery
+    - astroquery.alfalfa
+    - astroquery.alfalfa.tests
+    - astroquery.alma
+    - astroquery.alma.tests
+    - astroquery.atomic
+    - astroquery.atomic.tests
+    - astroquery.besancon
+    - astroquery.besancon.tests
+    - astroquery.cosmosim
+    - astroquery.cosmosim.tests
+    - astroquery.eso
+    - astroquery.eso.tests
+    - astroquery.extern
+    - astroquery.fermi
+    - astroquery.fermi.tests
+    - astroquery.gama
+    - astroquery.gama.tests
+    - astroquery.heasarc
+    - astroquery.heasarc.tests
+    - astroquery.irsa
+    - astroquery.irsa.tests
+    - astroquery.irsa_dust
+    - astroquery.irsa_dust.tests
+    - astroquery.lamda
+    - astroquery.lamda.tests
+    - astroquery.lcogt
+    - astroquery.lcogt.tests
+    - astroquery.magpis
+    - astroquery.magpis.tests
+    - astroquery.nasa_ads
+    - astroquery.nasa_ads.tests
+    - astroquery.ned
+    - astroquery.ned.tests
+    - astroquery.nist
+    - astroquery.nist.tests
+    - astroquery.nrao
+    - astroquery.nrao.tests
+    - astroquery.nvas
+    - astroquery.nvas.tests
+    - astroquery.ogle
+    - astroquery.ogle.tests
+    - astroquery.open_exoplanet_catalogue
+    - astroquery.open_exoplanet_catalogue.tests
+    - astroquery.sdss
+    - astroquery.sdss.tests
+    - astroquery.sha
+    - astroquery.sha.tests
+    - astroquery.simbad
+    - astroquery.simbad.tests
+    - astroquery.skyview
+    - astroquery.skyview.tests
+    - astroquery.splatalogue
+    - astroquery.splatalogue.tests
+    - astroquery.template_module
+    - astroquery.template_module.tests
+    - astroquery.tests
+    - astroquery.ukidss
+    - astroquery.ukidss.tests
+    - astroquery.utils
+    - astroquery.utils.tests
+    - astroquery.vizier
+    - astroquery.vizier.tests
+    - astroquery.xmatch
+    - astroquery.xmatch.tests
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  #home: The package home page
+  license: BSD
+  summary: 'Functions and classes to access online data resources'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 ## Dependencies for astropy affiliates
 hgtools==6.3
 keyring==5.3
-beautifulsoup4==4.3.2
 ## affiliated packages
 astropy-helpers==1.0.2
 astroquery==0.2.5


### PR DESCRIPTION
This adds a recipe template for `astroquery` to handle its dependency on `beautifulsoup4`, which anaconda calls `beautiful-soup`.

It also removes `beautifulsoup4` from the list of requirements.
