### PR TITLE
Add recipe template for ginga 

### DIFF
--- a/recipe_templates/ginga/bld.bat
+++ b/recipe_templates/ginga/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipe_templates/ginga/build.sh
+++ b/recipe_templates/ginga/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipe_templates/ginga/meta.yaml
+++ b/recipe_templates/ginga/meta.yaml
@@ -1,0 +1,87 @@
+package:
+  name: ginga
+  version: "{{version}}"
+
+source:
+  fn: ginga-{{version}}.tar.gz
+  url: https://pypi.python.org/packages/source/g/ginga/ginga-{{version}}.tar.gz
+  md5: {{md5}}
+  patches:
+   # List any patch files here
+    - setup.diff # [win and py3k]
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - ginga = ginga:main
+    #
+    # Would create an entry point called ginga that calls ginga.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy >=1.7
+
+  run:
+    - python
+    - numpy >=1.7
+
+test:
+  # Python imports
+  imports:
+    - ginga
+    - ginga.aggw
+    - ginga.base
+    - ginga.cairow
+    - ginga.canvas
+    - ginga.cvw
+    - ginga.doc
+    - ginga.gtkw
+    - ginga.gtkw.plugins
+    - ginga.gtkw.tests
+    - ginga.icons
+    - ginga.misc
+    - ginga.misc.plugins
+    - ginga.mockw
+    - ginga.mplw
+    - ginga.qtw
+    - ginga.qtw.plugins
+    - ginga.qtw.tests
+    - ginga.tests
+    - ginga.tkw
+    - ginga.util
+    - ginga.web
+    - ginga.web.pgw
+    - ginga.web.pgw.js
+    - ginga.web.pgw.templates
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://ejeschke.github.com/ginga
+  license: BSD License
+  summary: 'An astronomical image viewer and toolkit.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipe_templates/ginga/setup.diff
+++ b/recipe_templates/ginga/setup.diff
@@ -1,0 +1,11 @@
+--- setup copy.py	2015-07-18 13:33:43.000000000 -0500
++++ setup.py	2015-07-18 13:28:47.000000000 -0500
+@@ -12,7 +12,7 @@
+ from distutils.command.build_py import build_py
+ 
+ def read(fname):
+-    buf = open(os.path.join(srcdir, fname), 'r').read()
++    buf = open(os.path.join(srcdir, fname), 'r', encoding='utf-8').read()
+     return buf
+ 
+ # not yet working...


### PR DESCRIPTION
This PR adds a recipe template for ginga that applies a patch to the source for Windows builds on python 3.4. The problem is that the default encoding on Windows can't handle the Japanese characters in the `README.txt`. The patch adds an explicit encoding to the `open` statement in `setup.py` on Windows python 3.
