### PR TITLE
Add iminuit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@
 ## Dependencies for astropy affiliates
 hgtools==6.3
 keyring==5.3
+iminuit==1.1.1
+emcee==2.1.0
 ## affiliated packages
 astropy-helpers==1.0.3
 astroquery==0.2.5
@@ -24,5 +26,4 @@ gwcs==0.1.dev44
 pyregion==1.1.4
 astroML==0.3
 ginga==2.4.20150626080455
-emcee==2.1.0
 naima==0.5


### PR DESCRIPTION
This PR adds the latest stable iminuit (version 1.1.1: https://pypi.python.org/pypi/iminuit/1.1.1) to the Astropy anaconda channel.
iminuit is an optional dependency of Gammapy and sncosmo (cc @kbarbary).

This iminuit version only supports Python 2.

Python 3 support is available in the development version, but there are some issues that have to be fixed before we'll make a new release, and currently no-one has time. So if possible I'd like to get this in now and update iminuit in the future.
