### PR TITLE
Rename conda build var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,21 @@ env:
     matrix:
         - CONDA_PY=27
           CONDA_NPY=19
-          CONDA_BUILD="=$LATEST_GOOD_CONDA_BUILD"
+          CONDA_BUILD_VERSION="=$LATEST_GOOD_CONDA_BUILD"
         - CONDA_PY=34
           CONDA_NPY=19
-          CONDA_BUILD="=$LATEST_GOOD_CONDA_BUILD"
+          CONDA_BUILD_VERSION="=$LATEST_GOOD_CONDA_BUILD"
 
 matrix:
     fast_finish: true
 
     include:
         - os: linux
-          env: CONDA_PY=27 CONDA_BUILD=""  # selects latest version of conda-build
+          env: CONDA_PY=27 CONDA_BUILD_VERSION=""  # selects latest version of conda-build
 
     allow_failures:
         # Canary in the coal mine to check out new versions of conda-build
-        - env: CONDA_PY=27 CONDA_BUILD=""  # selects latest version of conda-build
+        - env: CONDA_PY=27 CONDA_BUILD_VERSION=""  # selects latest version of conda-build
 
 install:
     # Install miniconda, always the version specified by CONDA_PY, because
@@ -42,7 +42,7 @@ install:
     - conda config --set always_yes true
     - conda update --quiet conda
     # Install a couple of dependencies we need for sure.
-    - conda install --quiet --yes astropy conda-build$CONDA_BUILD anaconda-client jinja2 cython
+    - conda install --quiet --yes astropy conda-build$CONDA_BUILD_VERSION anaconda-client jinja2 cython pycrypto
     - conda config --add channels astropy
     # Install obvious-ci; run 2to3 first if the build is python 3.
     - cd Obvious-CI; if [[ ${CONDA_PY::1} == 3 ]]; then 2to3 -w .; fi; python setup.py install; cd ..

--- a/build_bdist.sh
+++ b/build_bdist.sh
@@ -8,7 +8,7 @@ for d in $to_build
     do
         cd $d
         # Try --offline in case astropy-helpers bootstrap conflicts with conda's shutdown of downloads.
-        python setup.py bdist_conda || python setup.py bdist_conda --offline || echo "Failed on $PWD"
+        python setup.py bdist_conda || echo "Failed on $PWD"
         cd ..
     done
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ imexam==0.5.2
 gwcs==0.1.dev44
 pyregion==1.1.4
 astroML==0.3
-ginga==2.4.20150626080455
+ginga==2.5.20150912012456
 naima==0.6
 pyephem==3.7.6.0
 reproject==0.1


### PR DESCRIPTION
In addition to fixing an exceptionally poor choice for the name of an environment variable this also bumps the ginga version, which should have the side effect of testing all of the build matrix entries.
