### PR TITLE
Add sunpy and dependencies.

### DIFF
--- a/recipe_templates/suds-jurko/bld.bat
+++ b/recipe_templates/suds-jurko/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipe_templates/suds-jurko/build.sh
+++ b/recipe_templates/suds-jurko/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipe_templates/suds-jurko/meta.yaml
+++ b/recipe_templates/suds-jurko/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: suds-jurko
+  version: {{version}}
+
+source:
+  fn: suds-jurko-{{version}}.tar.bz2
+  url: https://pypi.python.org/packages/source/s/suds-jurko/suds-jurko-{{version}}.tar.bz2
+  md5: {{md5}}
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - suds
+    - suds.bindings
+    - suds.mx
+    - suds.sax
+    - suds.transport
+    - suds.umx
+    - suds.xsd
+    - tests
+    - tests.external
+
+about:
+  home: http://bitbucket.org/jurko/suds
+  license:  GNU Library or Lesser General Public License (LGPL)
+  summary: "Lightweight SOAP client (Jurko's fork)"
+

--- a/recipe_templates/sunpy/bld.bat
+++ b/recipe_templates/sunpy/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install --offline --no-git
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipe_templates/sunpy/build.sh
+++ b/recipe_templates/sunpy/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install --offline --no-git
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipe_templates/sunpy/meta.yaml
+++ b/recipe_templates/sunpy/meta.yaml
@@ -1,0 +1,90 @@
+package:
+  name: sunpy
+  version: {{version}}
+
+source:
+  fn: sunpy-{{version}}.tar.gz
+  url: https://pypi.python.org/packages/source/s/sunpy/sunpy-{{version}}.tar.gz 
+  md5: {{md5}}
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy >1.7.1
+    - astropy >=1.0
+    - scipy
+    - matplotlib
+    - pandas
+    - mock
+    - nose
+
+  run:
+    - python
+    - numpy >1.7.1
+    - astropy >=1.0
+    - scipy
+    - pandas >=0.12.1
+    - matplotlib
+    - suds-jurko
+    - glymur
+    - sqlalchemy
+    - beautiful-soup
+    - requests
+    - bsddb               [unix]
+    - pytest
+    - scikit-image
+    - wcsaxes
+
+test:
+  # Python imports
+  imports:
+    - sunpy
+    - sunpy.cm
+    - sunpy.coordinates
+    - sunpy.data
+    - sunpy.data.test
+    - sunpy.data.test.waveunit
+    - sunpy.database
+    - sunpy.database.tests
+    - sunpy.image
+    - sunpy.image.tests
+    - sunpy.instr
+    - sunpy.instr.iris
+    - sunpy.io
+    - sunpy.io.tests
+    - sunpy.lightcurve
+    - sunpy.lightcurve.sources
+    - sunpy.lightcurve.tests
+    - sunpy.map
+    - sunpy.map.sources
+    - sunpy.map.tests
+    - sunpy.net
+    - sunpy.net.hek
+    - sunpy.net.hek2vso
+    - sunpy.net.helio
+    - sunpy.net.jsoc
+    - sunpy.net.tests
+    - sunpy.net.vso
+    - sunpy.physics
+    - sunpy.physics.transforms
+    - sunpy.roi
+    - sunpy.spectra
+    - sunpy.spectra.sources
+    - sunpy.spectra.tests
+    - sunpy.sun
+    - sunpy.sun.tests
+    - sunpy.tests
+    - sunpy.tests.tests
+    - sunpy.time
+    - sunpy.time.tests
+    - sunpy.util
+    - sunpy.util.tests
+    - sunpy.visualization
+    - sunpy.wcs
+    - sunpy.wcs.tests
+
+
+about:
+  home: http://www.sunpy.org/
+  license:  BSD License

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,7 @@ naima==0.6
 pyephem==3.7.6.0
 reproject==0.1
 astroplan==0.1
+suds-jurko==0.6
+contextlib2==0.4.0
+Glymur==0.8.2
+sunpy==0.6.1


### PR DESCRIPTION
This probably will not work as-is, for a start sunpy 0.6 will not build under 3.x and I think there maybe some work to be done on the recipe templates.

Feedback and suggestions welcome.
