### PR TITLE
update naima to 0.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ gwcs==0.1.dev44
 pyregion==1.1.4
 astroML==0.3
 ginga==2.5.20150912012456
-naima==0.6
+naima==0.6.1
 pyephem==3.7.6.0
 reproject==0.1
 astroplan==0.1


### PR DESCRIPTION
@mwcraig -- An additional note: the current emcee package in the binstar channel is built as `np19`, whereas most of the packages in the default anaconda channel are now `np110`, so there are some dependency problems. 
- How is it determined if a package is built with a fixed numpy version dependency? Can this be removed? As far as I know emcee works with any recent numpy.
- If the above is not possible, how can I trigger a rebuild with `np110`?
