### PR TITLE
Update reproject to 0.2

### DIFF
--- a/recipe_templates/reproject/meta.yaml
+++ b/recipe_templates/reproject/meta.yaml
@@ -1,4 +1,5 @@
 # Recipe needed to apply patch on Windows.
+# And to include numpy dependency, including pinning the version.
 
 package:
   name: reproject
@@ -31,11 +32,15 @@ requirements:
   build:
     - python
     - astropy
+    - numpy x.x
+    - numpy >1.7
 
   run:
     - python
     - astropy
     - scipy
+    - numpy x.x
+    - numpy >1.7
 
 test:
   # Python imports

--- a/recipe_templates/reproject/meta.yaml
+++ b/recipe_templates/reproject/meta.yaml
@@ -33,14 +33,14 @@ requirements:
     - python
     - astropy >=1
     - numpy x.x
-    - numpy >1.8
+    - numpy >=1.9
 
   run:
     - python
     - astropy >=1
     - scipy
     - numpy x.x
-    - numpy >1.8
+    - numpy >=1.9
 
 test:
   # Python imports

--- a/recipe_templates/reproject/meta.yaml
+++ b/recipe_templates/reproject/meta.yaml
@@ -33,14 +33,14 @@ requirements:
     - python
     - astropy
     - numpy x.x
-    - numpy >1.7
+    - numpy >1.8
 
   run:
     - python
     - astropy
     - scipy
     - numpy x.x
-    - numpy >1.7
+    - numpy >1.8
 
 test:
   # Python imports

--- a/recipe_templates/reproject/meta.yaml
+++ b/recipe_templates/reproject/meta.yaml
@@ -31,7 +31,7 @@ source:
 requirements:
   build:
     - python
-    - astropy
+    - astropy >=1
     - numpy x.x
     - numpy >1.8
 

--- a/recipe_templates/reproject/meta.yaml
+++ b/recipe_templates/reproject/meta.yaml
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - python
-    - astropy
+    - astropy >=1
     - scipy
     - numpy x.x
     - numpy >1.8

--- a/requirements.yml
+++ b/requirements.yml
@@ -141,7 +141,7 @@
 - name: reproject
   version: '0.2'
   astropy_helpers: true
-  numpy_compiled_extensions: false
+  numpy_compiled_extensions: true
 
 - name: astroplan
   version: '0.1'

--- a/requirements.yml
+++ b/requirements.yml
@@ -139,7 +139,7 @@
 
 # reproject has a recipe template
 - name: reproject
-  version: '0.1'
+  version: '0.2'
   astropy_helpers: true
   numpy_compiled_extensions: false
 


### PR DESCRIPTION
@astrofrog -- quick question: does reproject depend on the numpy ABI? Am trying to figure out whether it should be built directly against each version of numpy...
