### PR TITLE
Update version numbers to match PyPI

### DIFF
--- a/recipe_templates/asdf/bld.bat
+++ b/recipe_templates/asdf/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install --offline
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipe_templates/asdf/build.sh
+++ b/recipe_templates/asdf/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install --offline
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipe_templates/asdf/meta.yaml
+++ b/recipe_templates/asdf/meta.yaml
@@ -1,0 +1,97 @@
+# Recipe needed to:
+#
+# + Include numpy as a dependency
+# + Skip a couple of the import tests
+package:
+  name: asdf
+  version: "{{version}}"
+
+source:
+  fn: asdf-{{version}}.tar.gz
+  url: https://pypi.python.org/packages/source/a/asdf/asdf-{{version}}.tar.gz
+  md5: {{md5}}
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - asdf = asdf:main
+    #
+    # Would create an entry point called asdf that calls asdf.main()
+
+    - asdftool = pyasdf.commands.main:main
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyyaml >=3.10
+    - jsonschema >=2.3.0
+    - six >=1.9.0
+    - pytest >=2.7.2
+
+  run:
+    - python
+    - pyyaml >=3.10
+    - jsonschema >=2.3.0
+    - six >=1.9.0
+    - pytest >=2.7.2
+    - numpy
+
+test:
+  # Python imports
+  imports:
+    - pyasdf
+    - pyasdf.commands
+    - pyasdf.commands.tests
+    - pyasdf.compat
+    - pyasdf.compat._odict_py2
+    - pyasdf.extern
+    # - pyasdf.reference_files
+    # - pyasdf.schemas
+    - pyasdf.tags
+    - pyasdf.tags.core
+    - pyasdf.tags.core.tests
+    - pyasdf.tags.fits
+    - pyasdf.tags.fits.tests
+    - pyasdf.tags.time
+    - pyasdf.tags.time.tests
+    - pyasdf.tags.transform
+    - pyasdf.tags.transform.tests
+    - pyasdf.tags.unit
+    - pyasdf.tags.unit.tests
+    - pyasdf.tags.wcs
+    - pyasdf.tags.wcs.tests
+    - pyasdf.tests
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+    - asdftool --help
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://github.com/spacetelescope/pyasdf
+  license: BSD
+  summary: 'Python tools to handle ASDF files'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipe_templates/asdf/meta.yaml
+++ b/recipe_templates/asdf/meta.yaml
@@ -55,7 +55,7 @@ test:
     - pyasdf.commands
     - pyasdf.commands.tests
     - pyasdf.compat
-    - pyasdf.compat._odict_py2
+    # - pyasdf.compat._odict_py2
     - pyasdf.extern
     # - pyasdf.reference_files
     # - pyasdf.schemas

--- a/recipe_templates/gwcs/bld.bat
+++ b/recipe_templates/gwcs/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install --offline
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipe_templates/gwcs/build.sh
+++ b/recipe_templates/gwcs/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install --offline
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipe_templates/gwcs/meta.yaml
+++ b/recipe_templates/gwcs/meta.yaml
@@ -1,0 +1,68 @@
+# Recipe template is needed to add asdf to runtime requirements.
+package:
+  name: gwcs
+  version: "{{version}}"
+
+source:
+  fn: gwcs-{{version}}.tar.gz
+  url: https://pypi.python.org/packages/source/g/gwcs/gwcs-{{version}}.tar.gz
+  md5: {{md5}}
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - gwcs = gwcs:main
+    #
+    # Would create an entry point called gwcs that calls gwcs.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - astropy
+
+  run:
+    - python
+    - astropy
+    - asdf
+
+test:
+  # Python imports
+  imports:
+    - gwcs
+    - gwcs.tags
+    - gwcs.tags.tests
+    - gwcs.tests
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://gwcs.readthedocs.org/en/latest/
+  license: BSD
+  summary: 'Generalized World Coordinate System'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipe_templates/pydl/bld.bat
+++ b/recipe_templates/pydl/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install --offline
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipe_templates/pydl/build.sh
+++ b/recipe_templates/pydl/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install --offline
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipe_templates/pydl/meta.yaml
+++ b/recipe_templates/pydl/meta.yaml
@@ -1,0 +1,110 @@
+# Recipe template needed to skip the pca_gal script, which fails on Windows.
+package:
+  name: pydl
+  version: "{{version}}"
+
+source:
+  fn: pydl-{{version}}.tar.gz
+  url: https://pypi.python.org/packages/source/p/pydl/pydl-{{version}}.tar.gz
+  md5: {{md5}}
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - pydl = pydl:main
+    #
+    # Would create an entry point called pydl that calls pydl.main()
+
+    - get_juldate = pydl.goddard.astro.get_juldate:get_juldate_main
+    - hogg_iau_name = pydl.pydlutils.misc.hogg_iau_name:hogg_iau_name_main
+    - pca_gal = pydl.pydlspec2d.spec1d.pca_gal:pca_gal_main
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - astropy
+
+  run:
+    - python
+    - astropy
+
+test:
+  # Python imports
+  imports:
+    - pydl
+    - pydl.goddard
+    - pydl.goddard.astro
+    - pydl.goddard.astro.tests
+    - pydl.goddard.math
+    - pydl.goddard.math.tests
+    - pydl.goddard.misc
+    - pydl.goddard.misc.tests
+    - pydl.photoop
+    - pydl.photoop.photoobj
+    - pydl.photoop.photoobj.tests
+    - pydl.photoop.sdssio
+    - pydl.photoop.sdssio.tests
+    - pydl.photoop.window
+    - pydl.pydlspec2d
+    - pydl.pydlspec2d.spec1d
+    - pydl.pydlspec2d.spec1d.tests
+    - pydl.pydlspec2d.spec2d
+    - pydl.pydlspec2d.spec2d.tests
+    - pydl.pydlutils
+    - pydl.pydlutils.bspline
+    - pydl.pydlutils.bspline.tests
+    - pydl.pydlutils.cooling
+    - pydl.pydlutils.coord
+    - pydl.pydlutils.coord.tests
+    - pydl.pydlutils.image
+    - pydl.pydlutils.mangle
+    - pydl.pydlutils.mangle.tests
+    - pydl.pydlutils.math
+    - pydl.pydlutils.math.tests
+    - pydl.pydlutils.misc
+    - pydl.pydlutils.misc.tests
+    - pydl.pydlutils.sdss
+    - pydl.pydlutils.sdss.tests
+    - pydl.pydlutils.spheregroup
+    - pydl.pydlutils.spheregroup.tests
+    - pydl.pydlutils.trace
+    - pydl.pydlutils.trace.tests
+    - pydl.pydlutils.yanny
+    - pydl.pydlutils.yanny.tests
+    - pydl.tests
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+    - get_juldate --help
+    - hogg_iau_name --help
+    # - pca_gal --help
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://github.com/weaverba137/pydl
+  license: BSD License
+  summary: 'Astropy affiliated package'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/requirements.yml
+++ b/requirements.yml
@@ -117,7 +117,7 @@
 
 # asdf has a recipe template
 - name: asdf
-  version: 1.0.0
+  version: 1.0.1
   astropy_helpers: true
   numpy_compiled_extensions: false
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -116,7 +116,7 @@
 - name: asdf
   version: 1.0.0
   astropy_helpers: true
-  numpy_compiled_extensions: false
+  numpy_compiled_extensions: yes
 
 # pyregion has a recipe template
 - name: pyregion

--- a/requirements.yml
+++ b/requirements.yml
@@ -111,7 +111,12 @@
 - name: gwcs
   version: 0.5
   astropy_helpers: true
-  numpy_compiled_extensions: true
+  numpy_compiled_extensions: false
+
+- name: asdf
+  version: 1.0.0
+  astropy_helpers: true
+  numpy_compiled_extensions: false
 
 # pyregion has a recipe template
 - name: pyregion

--- a/requirements.yml
+++ b/requirements.yml
@@ -17,7 +17,7 @@
 
 # astropy-helpers has a recipe template
 - name: astropy-helpers
-  version: 1.0.3
+  version: 1.1.1
 
 - name: astroquery
   # Version should match the version on PyPI. Versions that could be

--- a/requirements.yml
+++ b/requirements.yml
@@ -108,6 +108,7 @@
   numpy_compiled_extensions: false
   python: '>2.6,<3'
 
+# gwcs has a recipe template
 - name: gwcs
   version: 0.5
   astropy_helpers: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -108,11 +108,10 @@
   numpy_compiled_extensions: false
   python: '>2.6,<3'
 
-# Chokes on no source
-# - name: gwcs
-#   version: 0.1.dev44
-#   astropy_helpers: true
-#   numpy_compiled_extensions: true
+- name: gwcs
+  version: 0.5
+  astropy_helpers: true
+  numpy_compiled_extensions: true
 
 # pyregion has a recipe template
 - name: pyregion

--- a/requirements.yml
+++ b/requirements.yml
@@ -48,6 +48,7 @@
   astropy_helpers: true
   numpy_compiled_extensions: false
 
+# pydl has a recipe template
 - name: pydl
   version: 0.4.1
   astropy_helpers: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -113,10 +113,11 @@
   astropy_helpers: true
   numpy_compiled_extensions: false
 
+# asdf has a recipe template
 - name: asdf
   version: 1.0.0
   astropy_helpers: true
-  numpy_compiled_extensions: yes
+  numpy_compiled_extensions: false
 
 # pyregion has a recipe template
 - name: pyregion

--- a/requirements.yml
+++ b/requirements.yml
@@ -49,7 +49,7 @@
   numpy_compiled_extensions: false
 
 - name: pydl
-  version: 0.3.0
+  version: 0.4.1
   astropy_helpers: true
   numpy_compiled_extensions: false
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -22,7 +22,7 @@
 - name: astroquery
   # Version should match the version on PyPI. Versions that could be
   # interpereted as numbers (e.g. 0.1) should be enclosed in quotes.
-  version: 0.2.6
+  version: 0.3.0
 
   # conda builds disable downloading, but astropy-helpers is typically
   # configured to try to autoupdate during install of affiliated


### PR DESCRIPTION
@mwcraig - I guess the only problematic point is `gwcs` that just got on PyPI very recently. All the others are trivial updates of the version numbers to match the latest releases on PyPI (with the exception of ginga, where I wasn't sure it's worth updating to the ever changing newest).
